### PR TITLE
remove stubs

### DIFF
--- a/content/docs/02-bioinformatics/03-testing.md
+++ b/content/docs/02-bioinformatics/03-testing.md
@@ -1,9 +1,0 @@
----
-title: "Testing & Continuous Integration"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.
-
-* tests
-* travis CI

--- a/content/docs/02-bioinformatics/10-data-cleaning.md
+++ b/content/docs/02-bioinformatics/10-data-cleaning.md
@@ -1,8 +1,0 @@
----
-title: "Data Cleaning"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.
-
-* Fauna / sacra ???

--- a/content/docs/02-bioinformatics/11-tree-building.md
+++ b/content/docs/02-bioinformatics/11-tree-building.md
@@ -1,8 +1,0 @@
----
-title: "Constructing Phylogenies using TreeTime"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.
-
-* This is an introduction to the model(s), not the interface to the module

--- a/content/docs/02-bioinformatics/12-frequencies.md
+++ b/content/docs/02-bioinformatics/12-frequencies.md
@@ -1,8 +1,0 @@
----
-title: "Frequencies"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.
-
-* This is an introduction to the model(s), not the interface to the module

--- a/content/docs/02-bioinformatics/13-titers.md
+++ b/content/docs/02-bioinformatics/13-titers.md
@@ -1,8 +1,0 @@
----
-title: "Titers"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.
-
-* This is an introduction to the model(s), not the interface to the module

--- a/content/docs/02-bioinformatics/14-scores.md
+++ b/content/docs/02-bioinformatics/14-scores.md
@@ -1,9 +1,0 @@
----
-title: "Scores"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.
-
-* This is an introduction to the model(s), not the interface to the module
-* LBI, masks etc

--- a/content/docs/02-bioinformatics/20-prepare-process.md
+++ b/content/docs/02-bioinformatics/20-prepare-process.md
@@ -1,6 +1,0 @@
----
-title: "Running Augur using Prepare & Process scripts (deprecated)"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.

--- a/content/docs/03-pathogen-builds/03-containers.md
+++ b/content/docs/03-pathogen-builds/03-containers.md
@@ -1,6 +1,0 @@
----
-title: "Containers & Nextstrain CLI"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.

--- a/content/docs/05-documentation-website/02-contributing.md
+++ b/content/docs/05-documentation-website/02-contributing.md
@@ -1,6 +1,0 @@
----
-title: "How to write markdown content for nextstrain.org"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.

--- a/content/docs/06-dev/01-servers.md
+++ b/content/docs/06-dev/01-servers.md
@@ -1,6 +1,0 @@
----
-title: "How is nextstrain.org served"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.

--- a/content/docs/06-dev/02-data-sources.md
+++ b/content/docs/06-dev/02-data-sources.md
@@ -1,6 +1,0 @@
----
-title: "How is data sourced from nextstrain.org"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.

--- a/content/docs/06-dev/03-travis-ci.md
+++ b/content/docs/06-dev/03-travis-ci.md
@@ -1,6 +1,0 @@
----
-title: "Travis CI"
-date: "2018-07-13"
----
-
-> Apologies, this documentation is not yet complete.


### PR DESCRIPTION
Now that we've got some documentation content (yay!) it looks weird to have so many stubs around, especially as these may not be filled in for quite some time.

This PR removes most of them, but they should be added back via new commits when (if) they're written.

I've purposefully left in the pathogen-builds intro which @barneypotter24 is currently writing, and the augur commands page which I hope we'll do ASAP.