### PR TITLE
Support people moving from Quickstart to the tutorials

### DIFF
--- a/content/about/03-methods/01-introduction.md
+++ b/content/about/03-methods/01-introduction.md
@@ -10,7 +10,7 @@ The Nextstrain architecture consists of three components. We maintain a database
 
 ## Data Collection
 
-We maintain a database of publicly available sequences and have written a number of scripts to ingest and canonicize data from different sources. This database, which is regularly updated, allows downloading of Zika, Ebola and influenza genomes in fasta format.
+We maintain a database of publicly available sequences and have written a number of scripts to ingest and canonicize data from different sources. This database, which is regularly updated, allows downloading of Zika, Ebola and influenza genomes in FASTA format.
 
 ## Filtering
 

--- a/content/docs/01-getting-started/03-zika-tutorial.md
+++ b/content/docs/01-getting-started/03-zika-tutorial.md
@@ -28,11 +28,10 @@ cd zika-tutorial
 
 ## Prepare the Sequences
 
-A Nextstrain build typically starts with a collection of pathogen sequences in a single FASTA file and a corresponding table of metadata describing those sequences in a tab-delimited text file.
+A Nextstrain build typically starts with a collection of pathogen sequences in a single [FASTA](https://en.wikipedia.org/wiki/FASTA_format) file and a corresponding table of metadata describing those sequences in a tab-delimited text file.
 For this tutorial, we will use an example data set with a subset of 34 viruses.
 
-The virus sequences are stored in a single [FASTA](https://en.wikipedia.org/wiki/FASTA_format) file.
-An example virus sequence record looks like the following, with the virus's strain id as the sequence name in the header line followed by the virus sequence.
+Each example virus sequence record looks like the following, with the virus's strain id as the sequence name in the header line followed by the virus sequence.
 
 ```
 >PAN/CDC_259359_V1_V3/2015

--- a/content/docs/01-getting-started/03-zika-tutorial.md
+++ b/content/docs/01-getting-started/03-zika-tutorial.md
@@ -7,7 +7,13 @@ This tutorial explains how to create a Nextstrain build for the Zika virus.
 We will first make the build step-by-step using an example data set.
 Then we will see how to automate this stepwise process by defining a pathogen build script.
 
-If you have not already, [install augur and auspice](/docs/getting-started/installation).
+If you haven't already worked through the [Quickstart](quickstart), you may want to back up and begin there before continuing with this tutorial.
+
+## Setup
+
+If you have the [Nextstrain command-line interface (CLI) tool](https://github.com/nextstrain/cli) installed from following the [Quickstart](quickstart), then you're all set!
+
+Otherwise, you'll need to either [install the CLI](quickstart#set-up-your-computer) or [install the Nextstrain components](../getting-started/installation) individually.
 
 ## Build steps
 
@@ -25,6 +31,16 @@ First, download the Zika pathogen build which includes example data and a pathog
 git clone https://github.com/nextstrain/zika-tutorial.git
 cd zika-tutorial
 ```
+
+Next, if you're using the Nextstrain CLI tool, use it to enter the Nextstrain build environment by running:
+
+```
+nextstrain shell .
+```
+
+Note the dot (`.`) as the last argument; it is important and indicates that your current directory (`zika-tutorial/`) is the build directory.
+Your command prompt will change to indicate you are in the build environment.
+(If you want to leave the build environment, run the command `exit`.)
 
 ## Prepare the Sequences
 
@@ -202,10 +218,21 @@ augur export \
 
 ## Visualize the Results
 
-To visualize the resulting Nextstrain build, copy the auspice files into the `data` directory of your local auspice installation, start auspice, and navigate to http://localhost:4000/local/zika in your browser.
+If you entered the Nextstrain build environment using `nextstrain shell` at the beginning of this tutorial, leave it now using the `exit` command and then use `nextstrain view` to visualize the Zika build output in `auspice/*.json`.
 
 ```
-# Copy files into auspice data directory.
+# Leave the shell you entered earlier.
+exit
+
+# View results in your auspice/ directory.
+nextstrain view auspice/
+```
+
+If you're not using the Nextstrain CLI shell, then copy the `auspice/*.json` files into the `data` directory of your local auspice installation and start auspice from there.
+
+```
+# Copy files into auspice data directory.  Adjust
+# paths if auspice isn't installed in ~/src/auspice/.
 mkdir ~/src/auspice/data/
 cp auspice/*.json ~/src/auspice/data/
 
@@ -214,20 +241,39 @@ cd ~/src/auspice/data/
 npm run dev
 ```
 
+Either way, navigate to <http://localhost:4000/local/zika> in your browser to view the results.
+
 ## Automate the Build with Snakemake
 
 While it is instructive to run all of the above commands manually, it is more practical to automate their execution with a single script.
-Nextstrain implements these automated pathogen builds with [Snakemake](https://snakemake.readthedocs.io/en/stable/index.html) by defining a `Snakefile` like the one in the Zika pathogen code.
+Nextstrain implements these automated pathogen builds with [Snakemake](https://snakemake.readthedocs.io) by defining a `Snakefile` like [the one in the Zika repository you downloaded](https://github.com/nextstrain/zika-tutorial/blob/master/Snakefile).
 
-To run the automated pathogen build for Zika, delete the output from the manual steps above and run Snakemake.
+First delete the output from the manual steps above.
 
 ```
 rm -rf results/ auspice/
+```
+
+Then, if you're using the Nextstrain CLI tool, run:
+
+```
+nextstrain build .
+```
+
+to run the automated pathogen build.
+
+If you're not using the Nextstrain CLI tool, run:
+
+```
 snakemake
 ```
 
-This command runs all of the manual steps above up through the auspice export.
-As before, you can copy the resulting auspice JSON files into your auspice installation directory and confirm that you have produced the same Zika build.
+The automated build runs all of the manual steps above up through the auspice export.
+View the results the same way you did before to confirm it produced the same Zika build you made manually.
+
+Note that automated builds will only re-run steps when the data changes.
+This means builds will pick up where they left off if they are restarted after being interrupted.
+If you want to force a re-run of the whole build, first remove any previous output with `nextstrain build . clean` or `snakemake clean`.
 
 ## Next steps
 

--- a/content/docs/01-getting-started/03-zika-tutorial.md
+++ b/content/docs/01-getting-started/03-zika-tutorial.md
@@ -3,8 +3,8 @@ title: "Zika Tutorial"
 date: "2018-08-29"
 ---
 
-This tutorial explains how to build a Nextstrain site for the Zika virus.
-We will first build a site step-by-step using an example data set.
+This tutorial explains how to create a Nextstrain build for the Zika virus.
+We will first make the build step-by-step using an example data set.
 Then we will see how to automate this stepwise process by defining a pathogen build script.
 
 If you have not already, [install augur and auspice](/docs/getting-started/installation).
@@ -26,7 +26,7 @@ cd zika-tutorial
 
 ## Prepare the Sequences
 
-A Nextstrain site typically starts with a collection of pathogen sequences in a single FASTA file and a corresponding table of metadata describing those sequences in a tab-delimited text file.
+A Nextstrain build typically starts with a collection of pathogen sequences in a single FASTA file and a corresponding table of metadata describing those sequences in a tab-delimited text file.
 For this tutorial, we will use an example data set with a subset of 34 viruses.
 
 The virus sequences are stored in a single [FASTA](https://en.wikipedia.org/wiki/FASTA_format) file.
@@ -201,7 +201,7 @@ augur export \
 
 ## Visualize the Results
 
-To visualize the resulting Nextstrain site, copy the auspice files into the `data` directory of your local auspice installation, start auspice, and navigate to http://localhost:4000/local/zika in your browser.
+To visualize the resulting Nextstrain build, copy the auspice files into the `data` directory of your local auspice installation, start auspice, and navigate to http://localhost:4000/local/zika in your browser.
 
 ```
 # Copy files into auspice data directory.
@@ -226,7 +226,7 @@ snakemake
 ```
 
 This command runs all of the manual steps above up through the auspice export.
-As before, you can copy the resulting auspice JSON files into your auspice installation directory and confirm that you have produced the same Zika site.
+As before, you can copy the resulting auspice JSON files into your auspice installation directory and confirm that you have produced the same Zika build.
 
 ## Next steps
 
@@ -236,4 +236,4 @@ As before, you can copy the resulting auspice JSON files into your auspice insta
 
 * Learn more about [creating and modifying snakemake files](../pathogen-builds/snakemake).
 
-* Fork the [Zika tutorial pathogen repository on GitHub](https://github.com/nextstrain/zika-tutorial), modify the Snakefile to make your own pathogen build, and view the resulting site at `https://nextstrain.org/community/<orgName>/<repoName>` for your corresponding GitHub username/org name and repository name.
+* Fork the [Zika tutorial pathogen repository on GitHub](https://github.com/nextstrain/zika-tutorial), modify the Snakefile to make your own pathogen build, and view the resulting build at `https://nextstrain.org/community/<orgName>/<repoName>` for your corresponding GitHub username/org name and repository name.

--- a/content/docs/01-getting-started/03-zika-tutorial.md
+++ b/content/docs/01-getting-started/03-zika-tutorial.md
@@ -11,11 +11,11 @@ If you have not already, [install augur and auspice](/docs/getting-started/insta
 
 Nextstrain builds typically require the following steps:
 
-1. prepare pathogen sequences and metadata
-2. align sequences
-3. construct a phylogeny from aligned sequences
-4. annotate the phylogeny with inferred ancestral pathogen dates, sequences, and traits
-5. export the annotated phylogeny and corresponding metadata into auspice-readable format
+1. Prepare pathogen sequences and metadata
+2. Align sequences
+3. Construct a phylogeny from aligned sequences
+4. Annotate the phylogeny with inferred ancestral pathogen dates, sequences, and traits
+5. Export the annotated phylogeny and corresponding metadata into auspice-readable format
 
 First, download the Zika pathogen build which includes example data and a pathogen build script.
 

--- a/content/docs/01-getting-started/03-zika-tutorial.md
+++ b/content/docs/01-getting-started/03-zika-tutorial.md
@@ -236,4 +236,4 @@ As before, you can copy the resulting auspice JSON files into your auspice insta
 
 * Learn more about [creating and modifying snakemake files](../pathogen-builds/snakemake).
 
-* Fork the [Zika tutorial pathogen repository on GitHub](https://github.com/nextstrain/zika-tutorial), modify the Snakefile to make your own pathogen build, and view the resulting build at `https://nextstrain.org/community/<orgName>/<repoName>` for your corresponding GitHub username/org name and repository name.
+* Fork the [Zika tutorial pathogen repository on GitHub](https://github.com/nextstrain/zika-tutorial), modify the Snakefile to make your own pathogen build, and learn [how to publish your build on nextstrain.org](../visualisation/introduction#viewing-your-data-through-nextstrainorg).

--- a/content/docs/01-getting-started/03-zika-tutorial.md
+++ b/content/docs/01-getting-started/03-zika-tutorial.md
@@ -9,6 +9,8 @@ Then we will see how to automate this stepwise process by defining a pathogen bu
 
 If you have not already, [install augur and auspice](/docs/getting-started/installation).
 
+## Build steps
+
 Nextstrain builds typically require the following steps:
 
 1. Prepare pathogen sequences and metadata

--- a/content/docs/01-getting-started/04-tb-tutorial.md
+++ b/content/docs/01-getting-started/04-tb-tutorial.md
@@ -17,7 +17,7 @@ If you have not already, [install augur and auspice](/docs/getting-started/insta
 The data from this tutorial is public and is a subset of the data from Lee et al.'s 2015 paper [Population genomics of *Mycobacterium tuberculosis* in the Inuit](http://www.pnas.org/content/112/44/13609).
 As location was anonymized in the paper, location data provided here was randomly chosen from the region for illustrative purposes.
 
-## Nextstrain steps
+## Build steps
 Nextstrain builds typically require the following steps:
 * Preparing data
 * Constructing a phylogeny

--- a/content/docs/01-getting-started/04-tb-tutorial.md
+++ b/content/docs/01-getting-started/04-tb-tutorial.md
@@ -312,4 +312,4 @@ As before, you can copy the resulting auspice JSON files into your auspice insta
 
 * Learn more about [creating and modifying snakemake files](../pathogen-builds/snakemake).
 
-* Fork the [TB pathogen repository on GitHub](https://github.com/nextstrain/tb), modify the Snakefile to make your own pathogen build, and view the resulting build at `https://nextstrain.org/community/<orgName>/<repoName>` for your corresponding GitHub username/org name and repository name.
+* Fork the [TB pathogen repository on GitHub](https://github.com/nextstrain/tb), modify the Snakefile to make your own pathogen build, and learn [how to publish your build on nextstrain.org](../visualisation/introduction#viewing-your-data-through-nextstrainorg).

--- a/content/docs/01-getting-started/04-tb-tutorial.md
+++ b/content/docs/01-getting-started/04-tb-tutorial.md
@@ -3,10 +3,10 @@ title: "TB Tutorial"
 date: "2018-08-29"
 ---
 
-This tutorial explains how to build a Nextstrain site for Tuberculosis sequences.
+This tutorial explains how to create a Nextstrain build for Tuberculosis sequences.
 However, much of it will be applicable to any run where you are starting with VCF files rather than Fasta files.
 
-We will first build a site step-by-step using an example data set. 
+We will first make the build step-by-step using an example data set. 
 Then we will see how to automate this stepwise process by defining a pathogen build script which contains the commands we will run below.
 
 Note that we will not use all the bioinformatics commands possible with Nextstrain.
@@ -53,7 +53,7 @@ cd tb
 
 ## Prepare the Sequences
 
-A Nextstrain site with VCF file input starts with:
+A Nextstrain build with VCF file input starts with:
 * A VCF file containing all the sequences you want to include (variable sites only)
 * A Fasta file of the reference sequence to which your VCF was mapped
 * A tab-delimited metadata file _we need better info about what format this should be..._
@@ -67,7 +67,7 @@ However, `augur` can take gzipped or un-gzipped VCF files.
 It can also produce either gzipped or un-gzipped VCF files as output. 
 Here, we'll usually keep our VCF files gzipped, by giving our output files endings like `.vcf.gz`, but you can specify `.vcf` instead.
 
-All the data you need to make the TB site is in the `data` and `config` folders.
+All the data you need to make the TB build is in the `data` and `config` folders.
 
 ### Filter the Sequences
 
@@ -302,7 +302,7 @@ snakemake
 ```
 
 This command runs all of the manual steps above up through the auspice export.
-As before, you can copy the resulting auspice JSON files into your auspice installation directory and confirm that you have produced the same TB site.
+As before, you can copy the resulting auspice JSON files into your auspice installation directory and confirm that you have produced the same TB build.
 
 ## Next steps
 
@@ -312,4 +312,4 @@ As before, you can copy the resulting auspice JSON files into your auspice insta
 
 * Learn more about [creating and modifying snakemake files](../pathogen-builds/snakemake).
 
-* Fork the [TB pathogen repository on GitHub](https://github.com/nextstrain/tb), modify the Snakefile to make your own pathogen build, and view the resulting site at `https://nextstrain.org/community/<orgName>/<repoName>` for your corresponding GitHub username/org name and repository name.
+* Fork the [TB pathogen repository on GitHub](https://github.com/nextstrain/tb), modify the Snakefile to make your own pathogen build, and view the resulting build at `https://nextstrain.org/community/<orgName>/<repoName>` for your corresponding GitHub username/org name and repository name.

--- a/content/docs/01-getting-started/04-tb-tutorial.md
+++ b/content/docs/01-getting-started/04-tb-tutorial.md
@@ -4,7 +4,7 @@ date: "2018-08-29"
 ---
 
 This tutorial explains how to create a Nextstrain build for Tuberculosis sequences.
-However, much of it will be applicable to any run where you are starting with VCF files rather than Fasta files.
+However, much of it will be applicable to any run where you are starting with VCF files rather than FASTA files.
 
 We will first make the build step-by-step using an example data set. 
 Then we will see how to automate this stepwise process by defining a pathogen build script which contains the commands we will run below.
@@ -55,7 +55,7 @@ cd tb
 
 A Nextstrain build with VCF file input starts with:
 * A VCF file containing all the sequences you want to include (variable sites only)
-* A Fasta file of the reference sequence to which your VCF was mapped
+* A FASTA file of the reference sequence to which your VCF was mapped
 * A tab-delimited metadata file _we need better info about what format this should be..._
 
 There are other files you will need if you want to perform certain steps, like masking. 
@@ -111,7 +111,7 @@ augur mask \
 
 Now our sequences are ready to start analysis. 
 
-With VCF files, we'll do this in two steps that are slightly different from Fasta-input.
+With VCF files, we'll do this in two steps that are slightly different from FASTA-input.
 1. First, we'll use only the variable sites to construct a tree quickly. This will give us the topology, but the branch lengths will be incorrect.
 2. Next, we'll consider the entire sequence to correct our branch lengths.
 At the same time, the sample date information will be used to create a time-resolved tree. 
@@ -190,7 +190,7 @@ augur ancestral \
 
 With `translate` we can identify amino acid mutations from the nucleotide mutations and a GFF file with gene coordinate annotations.
 The resulting JSON file contains amino acid mutations indexed by strain or internal node name and by gene name.
-`translate` will also produce a VCF-style file with the amino acid changes for each gene and each sequence, and Fasta file with the translated 'reference' genes which the VCF-style file 'maps' to. 
+`translate` will also produce a VCF-style file with the amino acid changes for each gene and each sequence, and FASTA file with the translated 'reference' genes which the VCF-style file 'maps' to.
 
 Because of the number of genes in TB, we will only translate some genes to save time. We can pass in a list of genes to translate (genes associated with drug resistance) using `--genes`. 
 Note that the `--reference-sequence` option is how you pass in the GFF file with the gene coordinates.

--- a/content/docs/01-getting-started/04-tb-tutorial.md
+++ b/content/docs/01-getting-started/04-tb-tutorial.md
@@ -4,7 +4,7 @@ date: "2018-08-29"
 ---
 
 This tutorial explains how to create a Nextstrain build for Tuberculosis sequences.
-However, much of it will be applicable to any run where you are starting with VCF files rather than FASTA files.
+However, much of it will be applicable to any run where you are starting with [VCF](https://en.wikipedia.org/wiki/Variant_Call_Format) files rather than [FASTA](https://en.wikipedia.org/wiki/FASTA_format) files.
 
 We will first make the build step-by-step using an example data set. 
 Then we will see how to automate this stepwise process by defining a pathogen build script which contains the commands we will run below.

--- a/content/docs/01-getting-started/04-tb-tutorial.md
+++ b/content/docs/01-getting-started/04-tb-tutorial.md
@@ -289,7 +289,7 @@ Navigate to the `auspice` directory and use `npm run dev' to start auspice.
 Open a browser and navigate to [localhost:4000/local/tb](http://localhost:4000/local/tb) to visualise your run.
 
 
-## Snakemake
+## Automate the Build with Snakemake
 
 While it is instructive to run all of the above commands manually, it is more practical to automate their execution with a single script.
 Nextstrain implements these automated pathogen builds with [Snakemake](https://snakemake.readthedocs.io/en/stable/index.html) by defining a `Snakefile` like the one supplied in the TB respository you cloned. 

--- a/content/docs/01-getting-started/04-tb-tutorial.md
+++ b/content/docs/01-getting-started/04-tb-tutorial.md
@@ -9,13 +9,16 @@ However, much of it will be applicable to any run where you are starting with [V
 We will first make the build step-by-step using an example data set. 
 Then we will see how to automate this stepwise process by defining a pathogen build script which contains the commands we will run below.
 
+If you haven't already worked through the [Quickstart](quickstart), you may want to back up and begin there before continuing with this tutorial.
+
 Note that we will not use all the bioinformatics commands possible with Nextstrain.
 After running this tutorial, you may want to read more about the [bioinformatics commands offered by Nextstrain](/docs/bioinformatics).
 
-If you have not already, [install augur and auspice](/docs/getting-started/installation).
+## Setup
 
-The data from this tutorial is public and is a subset of the data from Lee et al.'s 2015 paper [Population genomics of *Mycobacterium tuberculosis* in the Inuit](http://www.pnas.org/content/112/44/13609).
-As location was anonymized in the paper, location data provided here was randomly chosen from the region for illustrative purposes.
+If you have the [Nextstrain command-line interface (CLI) tool](https://github.com/nextstrain/cli) installed from following the [Quickstart](quickstart), then you're all set!
+
+Otherwise, you'll need to either [install the CLI](quickstart#set-up-your-computer) or [install the Nextstrain components](../getting-started/installation) individually.
 
 ## Build steps
 Nextstrain builds typically require the following steps:
@@ -46,6 +49,9 @@ Here, we'll follow these steps:
 
 ## Download Data
 
+The data in this tutorial is public and is a subset of the data from Lee et al.'s 2015 paper [Population genomics of *Mycobacterium tuberculosis* in the Inuit](http://www.pnas.org/content/112/44/13609).
+As location was anonymized in the paper, location data provided here was randomly chosen from the region for illustrative purposes.
+
 First, download the Tuberculosis (TB) build which includes example data and a pathogen build script.
 Then enter the directory you just cloned.
 
@@ -53,6 +59,16 @@ Then enter the directory you just cloned.
 git clone https://github.com/nextstrain/tb.git
 cd tb
 ```
+
+Next, if you're using the Nextstrain CLI tool, use it to enter the Nextstrain build environment by running:
+
+```
+nextstrain shell .
+```
+
+Note the dot (`.`) as the last argument; it is important and indicates that your current directory (`tb/`) is the build directory.
+Your command prompt will change to indicate you are in the build environment.
+(If you want to leave the build environment, run the command `exit`.)
 
 ## Prepare the Sequences
 
@@ -283,29 +299,64 @@ augur export \
     --output-meta auspice/tb_meta.json
 ```
 
-## Visualise the Results
+## Visualize the Results
 
-Copy the files to the `data` directory inside the `auspice` directory (create this folder if it does not exist). 
+If you entered the Nextstrain build environment using `nextstrain shell` at the beginning of this tutorial, leave it now using the `exit` command and then use `nextstrain view` to visualize the TB build output in `auspice/*.json`.
 
-Navigate to the `auspice` directory and use `npm run dev' to start auspice. 
+```
+# Leave the shell you entered earlier.
+exit
 
-Open a browser and navigate to [localhost:4000/local/tb](http://localhost:4000/local/tb) to visualise your run.
+# View results in your auspice/ directory.
+nextstrain view auspice/
+```
 
+If you're not using the Nextstrain CLI shell, then copy the `auspice/*.json` files into the `data` directory of your local auspice installation and start auspice from there.
+
+```
+# Copy files into auspice data directory.  Adjust
+# paths if auspice isn't installed in ~/src/auspice/.
+mkdir ~/src/auspice/data/
+cp auspice/*.json ~/src/auspice/data/
+
+# Start auspice.
+cd ~/src/auspice/data/
+npm run dev
+```
+
+Either way, navigate to <http://localhost:4000/local/tb> in your browser to view the results.
 
 ## Automate the Build with Snakemake
 
 While it is instructive to run all of the above commands manually, it is more practical to automate their execution with a single script.
-Nextstrain implements these automated pathogen builds with [Snakemake](https://snakemake.readthedocs.io/en/stable/index.html) by defining a `Snakefile` like the one supplied in the TB respository you cloned. 
+Nextstrain implements these automated pathogen builds with [Snakemake](https://snakemake.readthedocs.io) by defining a `Snakefile` like [the one in the TB repository you downloaded](https://github.com/nextstrain/tb/blob/master/Snakefile).
 
-To run the automated pathogen build for TB, delete the output from the manual steps above and run Snakemake.
+First delete the output from the manual steps above.
 
 ```
 rm -rf results/ auspice/
+```
+
+Then, if you're using the Nextstrain CLI tool, run:
+
+```
+nextstrain build .
+```
+
+to run the automated pathogen build.
+
+If you're not using the Nextstrain CLI tool, run:
+
+```
 snakemake
 ```
 
-This command runs all of the manual steps above up through the auspice export.
-As before, you can copy the resulting auspice JSON files into your auspice installation directory and confirm that you have produced the same TB build.
+The automated build runs all of the manual steps above up through the auspice export.
+View the results the same way you did before to confirm it produced the same TB build you made manually.
+
+Note that automated builds will only re-run steps when the data changes.
+This means builds will pick up where they left off if they are restarted after being interrupted.
+If you want to force a re-run of the whole build, first remove any previous output with `nextstrain build . clean` or `snakemake clean`.
 
 ## Next steps
 

--- a/content/docs/01-getting-started/04-tb-tutorial.md
+++ b/content/docs/01-getting-started/04-tb-tutorial.md
@@ -27,19 +27,22 @@ Nextstrain builds typically require the following steps:
 However, the commands that make up each step can vary depending on your pathogen and your analysis.
 Here, we'll follow these steps:
 
-1. Prepare pathogen sequences and metadata  
-    1.1 Filter the sequences (remove unwanted sequences and/or sample sequences)  
-    1.2 Mask the sequences (exclude regions of the sequence that are unreliable)  
-2. Construct a phylogeny  
-    2.1 Construct an initial tree (to get topology)  
-    2.2 Convert this into a time-resolved tree (to get accurate branch lengths)  
-3. Annotate the phylogeny  
-    3.1 Infer ancestral sequences  
-    3.2 Translate genes and identify amino-acid changes  
-    3.3 Reconstruct ancestral states (like location or host)  
-    3.4 Identify clades on the tree  
-    3.5 Identify drug resistance mutations  
-4. Export the final results into auspice-readable format
+ 1. Prepare pathogen sequences and metadata
+    1. Filter the sequences (remove unwanted sequences and/or sample sequences)
+    2. Mask the sequences (exclude regions of the sequence that are unreliable)
+
+ 2. Construct a phylogeny
+    1. Construct an initial tree (to get topology)
+    2. Convert this into a time-resolved tree (to get accurate branch lengths)
+
+ 3. Annotate the phylogeny
+    1. Infer ancestral sequences
+    2. Translate genes and identify amino-acid changes
+    3. Reconstruct ancestral states (like location or host)
+    4. Identify clades on the tree
+    5. Identify drug resistance mutations
+
+ 4. Export the final results into auspice-readable format
 
 ## Download Data
 


### PR DESCRIPTION
The primary piece of this PR is integrating into the tutorials a few additional instructions for using the Nextstrain CLI so that folks can easily move from the Quickstart into a tutorial.  This is a very natural progression that I'd like to support.

Also included in the branch is a fair bit of copy-editing and tweaks to align small differences between the two tutorials, but each change is broken out into it's own commit with a rationale. I recommend looking at the PR commit-by-commit from the start rather than all changes together, as the story and changes will be clearer taken individually.

@huddlej and @emmahodcroft I requested your reviews because the tutorials were written by you and I'd appreciate your thoughts and input.