### PR TITLE
 Automatically determine the last modification date of Markdown files from git

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+public/
+static/

--- a/content/about/01-overview/01-introduction.md
+++ b/content/about/01-overview/01-introduction.md
@@ -1,6 +1,5 @@
 ---
 title: "About Nextstrain"
-date: "2018-05-13"
 ---
 
 In the course of an infection and over an epidemic, viral pathogens naturally accumulate random mutations to their genomes.

--- a/content/about/03-methods/01-introduction.md
+++ b/content/about/03-methods/01-introduction.md
@@ -1,6 +1,5 @@
 ---
 title: "Methods overview"
-date: "2018-05-02"
 ---
 
 ## Nextstrain Components

--- a/content/docs/01-getting-started/01-introduction.md
+++ b/content/docs/01-getting-started/01-introduction.md
@@ -1,6 +1,5 @@
 ---
 title: "Nextstrain: analysis and visualisation of pathogen sequence data"
-date: "2018-08-23"
 ---
 
 Nextstrain is an open-source project to harness the scientific and public health potential of pathogen genome data. We provide a continually-updated view of publicly available data with powerful analytics and visualizations showing pathogen evolution and epidemic spread. Our goal is to aid epidemiological understanding and improve outbreak response. If you have any questions, or simply want to say hi, please give us a shout at hello@nextstrain.org.

--- a/content/docs/01-getting-started/02-quickstart.md
+++ b/content/docs/01-getting-started/02-quickstart.md
@@ -1,6 +1,5 @@
 ---
 title: Quickstart
-date: "2018-08-29"
 ---
 
 This guide uses the [Nextstrain command-line interface (CLI) tool](https://github.com/nextstrain/cli) to help you quickly get started running and viewing pathogen builds in Nextstrain with a minimum of fuss.

--- a/content/docs/01-getting-started/03-zika-tutorial.md
+++ b/content/docs/01-getting-started/03-zika-tutorial.md
@@ -1,6 +1,5 @@
 ---
 title: "Zika Tutorial"
-date: "2018-08-29"
 ---
 
 This tutorial explains how to build a Nextstrain site for the Zika virus.

--- a/content/docs/01-getting-started/04-tb-tutorial.md
+++ b/content/docs/01-getting-started/04-tb-tutorial.md
@@ -1,6 +1,5 @@
 ---
 title: "TB Tutorial"
-date: "2018-08-29"
 ---
 
 This tutorial explains how to build a Nextstrain site for Tuberculosis sequences.

--- a/content/docs/01-getting-started/05-installation.md
+++ b/content/docs/01-getting-started/05-installation.md
@@ -1,6 +1,5 @@
 ---
 title: "Installation"
-date: "2018-08-27"
 ---
 
 Nextstrain consists of a bioinformatics pipeline utility, `augur`, and a web application for data visualization, `auspice`.

--- a/content/docs/01-getting-started/06-windows-help.md
+++ b/content/docs/01-getting-started/06-windows-help.md
@@ -1,6 +1,5 @@
 ---
 title: "Help! I'm using Windows"
-date: "2018-08-27"
 ---
 
 Nextstrain documentation assumes users are running a Unix-based system like Mac OS X or Linux. 

--- a/content/docs/02-bioinformatics/01-introduction.md
+++ b/content/docs/02-bioinformatics/01-introduction.md
@@ -1,6 +1,5 @@
 ---
 title: "Bioinformatics Introduction"
-date: "2018-08-24"
 ---
 
 Nextstrain's bioinformatics toolkit is called __augur__.

--- a/content/docs/02-bioinformatics/02-commands.md
+++ b/content/docs/02-bioinformatics/02-commands.md
@@ -1,6 +1,5 @@
 ---
 title: "Bioinformatics Commands"
-date: "2018-07-13"
 ---
 
 > Apologies, this documentation is not yet complete.

--- a/content/docs/02-bioinformatics/04-output-jsons.md
+++ b/content/docs/02-bioinformatics/04-output-jsons.md
@@ -1,6 +1,5 @@
 ---
 title: "Format of JSON files exported by augur and consumed by auspice"
-date: "2018-08-29"
 ---
 
 We use JSONs as the interchange file format between Augur (the bioinformatics tooling) and Auspice (the visualisation app).

--- a/content/docs/03-pathogen-builds/01-introduction.md
+++ b/content/docs/03-pathogen-builds/01-introduction.md
@@ -1,6 +1,5 @@
 ---
 title: "Introduction to Running Nextstrain Pathogen Builds"
-date: "2018-07-13"
 ---
 
 > Apologies, this documentation is not yet complete.

--- a/content/docs/03-pathogen-builds/02-snakemake.md
+++ b/content/docs/03-pathogen-builds/02-snakemake.md
@@ -1,6 +1,5 @@
 ---
 title: "Snakemake and recommended best practices"
-date: "2018-07-13"
 ---
 
 > Apologies, this documentation is not yet complete.

--- a/content/docs/04-visualisation/01-introduction.md
+++ b/content/docs/04-visualisation/01-introduction.md
@@ -1,6 +1,5 @@
 ---
 title: "Interactive Bioinformatics Visualisation using Auspice"
-date: "2018-07-13"
 ---
 
 Visualisation of bioinformatics results is an integral part of current phylodynamics, both for data exploration and communication.

--- a/content/docs/04-visualisation/05-narratives.md
+++ b/content/docs/04-visualisation/05-narratives.md
@@ -1,6 +1,5 @@
 ---
 title: "Communicating results using Narratives"
-date: "2018-08-22"
 ---
 
 Narratives are a method of data-driven storytelling.

--- a/content/docs/05-documentation-website/01-introduction.md
+++ b/content/docs/05-documentation-website/01-introduction.md
@@ -1,6 +1,5 @@
 ---
 title: "Documentation Website Introduction"
-date: "2018-07-13"
 ---
 
 > Apologies, this documentation is not yet complete.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:pp": "gatsby build --prefix-paths",
     "build:gh": "npm run clean && npm run build:pp && gh-pages -d public",
     "clean": "rm -rf public",
-    "lint:js": "eslint --ext .js,.jsx --ignore-pattern public,static .",
+    "lint:js": "eslint --ext .js,.jsx .",
     "lint:md": "remark content/posts/",
     "write-good": "write-good $(glob 'content/posts/**/*.md')",
     "format:js": "prettier '**/*.{js,jsx}' --write",

--- a/src/templates/displayMarkdown.jsx
+++ b/src/templates/displayMarkdown.jsx
@@ -56,6 +56,16 @@ export default class GenericTemplate extends React.Component {
       </div>
     );
   }
+
+  renderPostDate(postNode) {
+    const date = postNode.frontmatter.date;
+    const commitDate = postNode.fields.lastCommitDate;
+
+    return date
+      ? (<PostDate>{ date }</PostDate>)
+      : (<PostDate>Last modified { commitDate }</PostDate>);
+  }
+
   render() {
     // console.log("genericTemplate props:", this.props)
     const { slug } = this.props.pathContext; /* defined by createPages */
@@ -82,10 +92,10 @@ export default class GenericTemplate extends React.Component {
                 {showAuthor ? (
                   <div>
                     <PostAuthor>{post.author}</PostAuthor>
-                    <PostDate>{post.date || postNode.fields.lastCommitDate}</PostDate>
+                    { this.renderPostDate(postNode) }
                   </div>
                 ) : (
-                  <PostDate>Last modified {post.date || postNode.fields.lastCommitDate}</PostDate>
+                  this.renderPostDate(postNode)
                 )}
               </PostAuthorSurrounds>
               <PostTitle>{post.title}</PostTitle>

--- a/src/templates/displayMarkdown.jsx
+++ b/src/templates/displayMarkdown.jsx
@@ -82,10 +82,10 @@ export default class GenericTemplate extends React.Component {
                 {showAuthor ? (
                   <div>
                     <PostAuthor>{post.author}</PostAuthor>
-                    <PostDate>{post.date}</PostDate>
+                    <PostDate>{post.date || postNode.fields.lastCommitDate}</PostDate>
                   </div>
                 ) : (
-                  <PostDate>Last modified {post.date}</PostDate>
+                  <PostDate>Last modified {post.date || postNode.fields.lastCommitDate}</PostDate>
                 )}
               </PostAuthorSurrounds>
               <PostTitle>{post.title}</PostTitle>
@@ -208,6 +208,7 @@ export const pageQuery = graphql`
       }
       fields {
         slug
+        lastCommitDate(formatString: "YYYY-MM-DD")
       }
     }
   }


### PR DESCRIPTION
This frees us from having to remember to bump the date in the frontmatter when we make changes.

See each commit message for rationale.